### PR TITLE
fix: remove reference to a wip branch

### DIFF
--- a/projects/demo-pm.yaml
+++ b/projects/demo-pm.yaml
@@ -46,4 +46,3 @@ repos:
 
   meta-tedge-bin:
     url: "https://github.com/thin-edge/meta-tedge-bin"
-    branch: prod-mender-state-scripts

--- a/projects/demo-qemu.yaml
+++ b/projects/demo-qemu.yaml
@@ -41,4 +41,3 @@ repos:
 
   meta-tedge-bin:
     url: "https://github.com/thin-edge/meta-tedge-bin"
-    branch: prod-mender-state-scripts


### PR DESCRIPTION
Remove reference to an old wip branch for meta-tedge-bin, and use the default branch