### PR TITLE
fix: update meta-tedge-bin to fix mosquitto permissions

### DIFF
--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ clean:
 # You need to run this if you are working on a branch and would like up-to-date
 # changes
 update-lock file *args="":
-    python3 -m kas dump --lock {{args}} {{file}} --inplace
+    python3 -m kas dump --update --lock {{args}} {{file}} --inplace
 
 # Update the lock file used by the main demo (convinience task)
 update-demo-lock *args="":

--- a/projects/demo.lock.yaml
+++ b/projects/demo.lock.yaml
@@ -9,6 +9,6 @@ overrides:
         meta-raspberrypi:
             commit: 59a6a1b5dd1e21189adec49c61eae04ed3e70338
         meta-tedge-bin:
-            commit: 1e16ea584a9226cda0878f09d6fc5cd0bf0bae1c
+            commit: a955f141336f9170edd2438ed8ae5e60e732d5d8
         poky:
             commit: 3e73216a32a2b01916eb8c555a41579bd69a47aa


### PR DESCRIPTION
Update dependencies to include fix on mosquitto permissions on the device certificate (prior to healthcheck)