### PR TITLE
chore: bump meta-tedge-bin and poky references

### DIFF
--- a/projects/demo.lock.yaml
+++ b/projects/demo.lock.yaml
@@ -9,6 +9,6 @@ overrides:
         meta-raspberrypi:
             commit: 59a6a1b5dd1e21189adec49c61eae04ed3e70338
         meta-tedge-bin:
-            commit: 8d2c4286a8eb1bc3cb29b29ed19ac82c2b625943
+            commit: fa4e7d0da05479fb52400087f0630ad4dc6be099
         poky:
-            commit: 755632c2fcab43aa05cdcfa529727064b045073c
+            commit: 1520bf97aaa9cf1b340c84e35f3cfe4b7641f3bb


### PR DESCRIPTION
Update the following layers to the latest version:
* poky
* meta-tedge-bin