### PR TITLE
docs: add missing build dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To start off, you will need to install the project and Yocto dependencies.
     **Ubuntu 20.04 LTS**
 
     ```
-    sudo apt install gawk wget git diffstat unzip texinfo gcc build-essential chrpath socat cpio python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev pylint3 xterm python3-subunit mesa-common-dev zstd liblz4-tool
+    sudo apt install file gawk wget git diffstat unzip texinfo gcc build-essential chrpath socat cpio python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev pylint3 xterm python3-subunit mesa-common-dev zstd liblz4-tool
     ```
 
     If you having troubles please consult the [Yocto Documentation](https://docs.yoctoproject.org/kirkstone/brief-yoctoprojectqs/index.html#building-your-image)


### PR DESCRIPTION
Add `file` to list of build dependencies as it is not installed by default on ubuntu minimal images.