### PR TITLE
ci: only install tooling on hosted runner

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,11 +34,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      # Only install tooling if not running on a self-hosted runner as the tools are already pre-installed
       - uses: taiki-e/install-action@just
+        if: ${{ !startsWith(runner.name, 'tedge') }}
       - uses: actions/setup-python@v5
+        if: ${{ !startsWith(runner.name, 'tedge') }}
         with:
           python-version: '3.8'
       - run: pip3 install kas
+        if: ${{ !startsWith(runner.name, 'tedge') }}
+
       - name: Build
         run: just build-project projects/${{ matrix.project }}.yaml
         env:


### PR DESCRIPTION
Only install tools when running on a hosted runner (not a self-hosted runner) as the runner is not running as root, as has some restrictions.