### PR TITLE
feat(all): use debian package manager by default and install gnupg

### DIFF
--- a/projects/config/common.yaml
+++ b/projects/config/common.yaml
@@ -8,8 +8,9 @@ bblayers_conf_header:
 
 local_conf_header:
   meta-common: |
-    PACKAGE_CLASSES ?= "package_rpm"
+    PACKAGE_CLASSES ?= "package_deb"
     VOLATILE_LOG_DIR = "no"
+    IMAGE_INSTALL:append = " gnupg"
     EXTRA_IMAGE_FEATURES ?= "debug-tweaks ssh-server-dropbear"
     INIT_MANAGER="systemd"
 


### PR DESCRIPTION
Switch the default package manager from rpm to deb, as thin-edge.io is more debian orientated (less of a maintenance overhead for us).

Include the gnupg package in all images so that secure (https) repositories can also be configured to install additional software without a firmware image update (e.g. from the community repository).
