### PR TITLE
chore: update lock files to latest commits

### DIFF
--- a/projects/tedge-bin-rauc.lock.yaml
+++ b/projects/tedge-bin-rauc.lock.yaml
@@ -3,7 +3,7 @@ header:
 overrides:
     repos:
         meta-openembedded:
-            commit: 5a6f7925bd2b885955c942573f70a5594f231563
+            commit: 70b217ecc812296d98e1aa027a7d182a8019dded
         meta-raspberrypi:
             commit: 9dc6673d41044f1174551120ce63501421dbcd85
         meta-rauc:
@@ -13,4 +13,4 @@ overrides:
         meta-tedge:
             commit: 8a5a122c6661f9dcb18b6994d927b25f2ee8c06e
         poky:
-            commit: 2b21c6009aa6b955e1a0e7312c3c0ad66557681b
+            commit: e575d02196b0013c25f8064e4dbe3fc2a0ef72d0

--- a/projects/tedge-mender.lock.yaml
+++ b/projects/tedge-mender.lock.yaml
@@ -3,9 +3,9 @@ header:
 overrides:
     repos:
         meta-mender:
-            commit: 60db3bb689c956f7b148480b2c7a02351cbe4dbc
+            commit: f5455b66f259a49d78ca96f0730b57f0f6b3a6a5
         meta-openembedded:
-            commit: 5a6f7925bd2b885955c942573f70a5594f231563
+            commit: 70b217ecc812296d98e1aa027a7d182a8019dded
         meta-raspberrypi:
             commit: 9dc6673d41044f1174551120ce63501421dbcd85
         meta-rust:
@@ -13,4 +13,4 @@ overrides:
         meta-tedge:
             commit: 8a5a122c6661f9dcb18b6994d927b25f2ee8c06e
         poky:
-            commit: 2b21c6009aa6b955e1a0e7312c3c0ad66557681b
+            commit: e575d02196b0013c25f8064e4dbe3fc2a0ef72d0

--- a/projects/tedge-rauc.lock.yaml
+++ b/projects/tedge-rauc.lock.yaml
@@ -3,7 +3,7 @@ header:
 overrides:
     repos:
         meta-openembedded:
-            commit: 5a6f7925bd2b885955c942573f70a5594f231563
+            commit: 70b217ecc812296d98e1aa027a7d182a8019dded
         meta-raspberrypi:
             commit: 9dc6673d41044f1174551120ce63501421dbcd85
         meta-rauc:
@@ -15,4 +15,4 @@ overrides:
         meta-tedge:
             commit: 8a5a122c6661f9dcb18b6994d927b25f2ee8c06e
         poky:
-            commit: 2b21c6009aa6b955e1a0e7312c3c0ad66557681b
+            commit: e575d02196b0013c25f8064e4dbe3fc2a0ef72d0


### PR DESCRIPTION
Update lock files to pull in latest changes from all layers (for the configured branch).