### PR TITLE
chore: update project lock files

### DIFF
--- a/justfile
+++ b/justfile
@@ -41,3 +41,7 @@ publish *args="":
 
 runqemu config="./projects/tedge-rauc.yaml":
     kas shell {{config}} -c 'runqemu'
+
+# Update the lock files of all projects
+update-all-locks:
+    find ./projects -maxdepth 1 \( -name "*.yaml" -a ! -name "*.lock.*" \) -exec just update-lock {} \;

--- a/projects/demo-pm.lock.yaml
+++ b/projects/demo-pm.lock.yaml
@@ -13,6 +13,6 @@ overrides:
         meta-rust:
             commit: 9611b42d73c7546c3d845da380943a0a4f4205f0
         meta-tedge:
-            commit: 52f4a50d993f999ed54b2d2c328bc124a03bd4c4
+            commit: 6b434ba1d0b32959d11ac2da61f30cab78df61f6
         poky:
             commit: db3cb6f1138d1765fb64d2415083c8503f318a5f

--- a/projects/demo-pm.lock.yaml
+++ b/projects/demo-pm.lock.yaml
@@ -3,7 +3,7 @@ header:
 overrides:
     repos:
         meta-openembedded:
-            commit: 5a6f7925bd2b885955c942573f70a5594f231563
+            commit: 0560b848996a0feb410a8cd8ca07c60fe2f3b5bc
         meta-raspberrypi:
             commit: 9dc6673d41044f1174551120ce63501421dbcd85
         meta-rauc:
@@ -13,6 +13,6 @@ overrides:
         meta-rust:
             commit: 9611b42d73c7546c3d845da380943a0a4f4205f0
         meta-tedge:
-            commit: bb1afcd8cf0d13be08019691aefcca733117d0fd
+            commit: 52f4a50d993f999ed54b2d2c328bc124a03bd4c4
         poky:
-            commit: 2b21c6009aa6b955e1a0e7312c3c0ad66557681b
+            commit: db3cb6f1138d1765fb64d2415083c8503f318a5f

--- a/projects/demo-qemu.lock.yaml
+++ b/projects/demo-qemu.lock.yaml
@@ -3,12 +3,12 @@ header:
 overrides:
     repos:
         meta-mender:
-            commit: 60db3bb689c956f7b148480b2c7a02351cbe4dbc
+            commit: f5455b66f259a49d78ca96f0730b57f0f6b3a6a5
         meta-openembedded:
-            commit: 5a6f7925bd2b885955c942573f70a5594f231563
+            commit: 0560b848996a0feb410a8cd8ca07c60fe2f3b5bc
         meta-rust:
             commit: 9611b42d73c7546c3d845da380943a0a4f4205f0
         meta-tedge:
-            commit: bb1afcd8cf0d13be08019691aefcca733117d0fd
+            commit: 52f4a50d993f999ed54b2d2c328bc124a03bd4c4
         poky:
-            commit: 2b21c6009aa6b955e1a0e7312c3c0ad66557681b
+            commit: db3cb6f1138d1765fb64d2415083c8503f318a5f

--- a/projects/demo-qemu.lock.yaml
+++ b/projects/demo-qemu.lock.yaml
@@ -9,6 +9,6 @@ overrides:
         meta-rust:
             commit: 9611b42d73c7546c3d845da380943a0a4f4205f0
         meta-tedge:
-            commit: 52f4a50d993f999ed54b2d2c328bc124a03bd4c4
+            commit: 6b434ba1d0b32959d11ac2da61f30cab78df61f6
         poky:
             commit: db3cb6f1138d1765fb64d2415083c8503f318a5f

--- a/projects/demo.lock.yaml
+++ b/projects/demo.lock.yaml
@@ -13,6 +13,6 @@ overrides:
         meta-rust:
             commit: 9611b42d73c7546c3d845da380943a0a4f4205f0
         meta-tedge:
-            commit: 52f4a50d993f999ed54b2d2c328bc124a03bd4c4
+            commit: 6b434ba1d0b32959d11ac2da61f30cab78df61f6
         poky:
             commit: db3cb6f1138d1765fb64d2415083c8503f318a5f

--- a/projects/demo.lock.yaml
+++ b/projects/demo.lock.yaml
@@ -3,7 +3,7 @@ header:
 overrides:
     repos:
         meta-openembedded:
-            commit: 5a6f7925bd2b885955c942573f70a5594f231563
+            commit: 0560b848996a0feb410a8cd8ca07c60fe2f3b5bc
         meta-raspberrypi:
             commit: 9dc6673d41044f1174551120ce63501421dbcd85
         meta-rauc:
@@ -13,6 +13,6 @@ overrides:
         meta-rust:
             commit: 9611b42d73c7546c3d845da380943a0a4f4205f0
         meta-tedge:
-            commit: bb1afcd8cf0d13be08019691aefcca733117d0fd
+            commit: 52f4a50d993f999ed54b2d2c328bc124a03bd4c4
         poky:
-            commit: 2b21c6009aa6b955e1a0e7312c3c0ad66557681b
+            commit: db3cb6f1138d1765fb64d2415083c8503f318a5f

--- a/projects/tedge-bin-rauc.lock.yaml
+++ b/projects/tedge-bin-rauc.lock.yaml
@@ -3,7 +3,7 @@ header:
 overrides:
     repos:
         meta-openembedded:
-            commit: 70b217ecc812296d98e1aa027a7d182a8019dded
+            commit: 0560b848996a0feb410a8cd8ca07c60fe2f3b5bc
         meta-raspberrypi:
             commit: 9dc6673d41044f1174551120ce63501421dbcd85
         meta-rauc:
@@ -11,6 +11,6 @@ overrides:
         meta-rauc-community:
             commit: c3f3ab4c587f51a74a76546ce2813c8be7c6d128
         meta-tedge:
-            commit: 8a5a122c6661f9dcb18b6994d927b25f2ee8c06e
+            commit: 52f4a50d993f999ed54b2d2c328bc124a03bd4c4
         poky:
-            commit: e575d02196b0013c25f8064e4dbe3fc2a0ef72d0
+            commit: db3cb6f1138d1765fb64d2415083c8503f318a5f

--- a/projects/tedge-bin-rauc.lock.yaml
+++ b/projects/tedge-bin-rauc.lock.yaml
@@ -11,6 +11,6 @@ overrides:
         meta-rauc-community:
             commit: c3f3ab4c587f51a74a76546ce2813c8be7c6d128
         meta-tedge:
-            commit: 52f4a50d993f999ed54b2d2c328bc124a03bd4c4
+            commit: 6b434ba1d0b32959d11ac2da61f30cab78df61f6
         poky:
             commit: db3cb6f1138d1765fb64d2415083c8503f318a5f

--- a/projects/tedge-mender.lock.yaml
+++ b/projects/tedge-mender.lock.yaml
@@ -5,12 +5,12 @@ overrides:
         meta-mender:
             commit: f5455b66f259a49d78ca96f0730b57f0f6b3a6a5
         meta-openembedded:
-            commit: 70b217ecc812296d98e1aa027a7d182a8019dded
+            commit: 0560b848996a0feb410a8cd8ca07c60fe2f3b5bc
         meta-raspberrypi:
             commit: 9dc6673d41044f1174551120ce63501421dbcd85
         meta-rust:
             commit: 9611b42d73c7546c3d845da380943a0a4f4205f0
         meta-tedge:
-            commit: 8a5a122c6661f9dcb18b6994d927b25f2ee8c06e
+            commit: 52f4a50d993f999ed54b2d2c328bc124a03bd4c4
         poky:
-            commit: e575d02196b0013c25f8064e4dbe3fc2a0ef72d0
+            commit: db3cb6f1138d1765fb64d2415083c8503f318a5f

--- a/projects/tedge-mender.lock.yaml
+++ b/projects/tedge-mender.lock.yaml
@@ -11,6 +11,6 @@ overrides:
         meta-rust:
             commit: 9611b42d73c7546c3d845da380943a0a4f4205f0
         meta-tedge:
-            commit: 52f4a50d993f999ed54b2d2c328bc124a03bd4c4
+            commit: 6b434ba1d0b32959d11ac2da61f30cab78df61f6
         poky:
             commit: db3cb6f1138d1765fb64d2415083c8503f318a5f

--- a/projects/tedge-rauc.lock.yaml
+++ b/projects/tedge-rauc.lock.yaml
@@ -13,6 +13,6 @@ overrides:
         meta-rust:
             commit: 9611b42d73c7546c3d845da380943a0a4f4205f0
         meta-tedge:
-            commit: 52f4a50d993f999ed54b2d2c328bc124a03bd4c4
+            commit: 6b434ba1d0b32959d11ac2da61f30cab78df61f6
         poky:
             commit: db3cb6f1138d1765fb64d2415083c8503f318a5f

--- a/projects/tedge-rauc.lock.yaml
+++ b/projects/tedge-rauc.lock.yaml
@@ -3,7 +3,7 @@ header:
 overrides:
     repos:
         meta-openembedded:
-            commit: 70b217ecc812296d98e1aa027a7d182a8019dded
+            commit: 0560b848996a0feb410a8cd8ca07c60fe2f3b5bc
         meta-raspberrypi:
             commit: 9dc6673d41044f1174551120ce63501421dbcd85
         meta-rauc:
@@ -13,6 +13,6 @@ overrides:
         meta-rust:
             commit: 9611b42d73c7546c3d845da380943a0a4f4205f0
         meta-tedge:
-            commit: 8a5a122c6661f9dcb18b6994d927b25f2ee8c06e
+            commit: 52f4a50d993f999ed54b2d2c328bc124a03bd4c4
         poky:
-            commit: e575d02196b0013c25f8064e4dbe3fc2a0ef72d0
+            commit: db3cb6f1138d1765fb64d2415083c8503f318a5f


### PR DESCRIPTION
Update the project lock files to use the latest commits from each of the layers.

There is a new just task to update all project lock files using:

```sh
just update-all-locks
```