### PR TITLE
fix: firmware status updates sent to incorrect topic

### DIFF
--- a/projects/tedge-bin-rauc.lock.yaml
+++ b/projects/tedge-bin-rauc.lock.yaml
@@ -11,6 +11,6 @@ overrides:
         meta-rauc-community:
             commit: c3f3ab4c587f51a74a76546ce2813c8be7c6d128
         meta-tedge:
-            commit: 18e085137f589c7473a045da2deeb358564992df
+            commit: 0f2e1f67f7ed699b7cdc97d46c7dfde9e9457ebd
         poky:
             commit: 322d4df8cb51b531a998de92298914a6710d7677

--- a/projects/tedge-mender-qemu.lock.yaml
+++ b/projects/tedge-mender-qemu.lock.yaml
@@ -9,6 +9,6 @@ overrides:
         meta-rust:
             commit: a5136be2ba408af1cc8afcde1c8e3d787dadd934
         meta-tedge:
-            commit: 18e085137f589c7473a045da2deeb358564992df
+            commit: 0f2e1f67f7ed699b7cdc97d46c7dfde9e9457ebd
         poky:
             commit: 322d4df8cb51b531a998de92298914a6710d7677

--- a/projects/tedge-mender.lock.yaml
+++ b/projects/tedge-mender.lock.yaml
@@ -11,6 +11,6 @@ overrides:
         meta-rust:
             commit: a5136be2ba408af1cc8afcde1c8e3d787dadd934
         meta-tedge:
-            commit: 18e085137f589c7473a045da2deeb358564992df
+            commit: 0f2e1f67f7ed699b7cdc97d46c7dfde9e9457ebd
         poky:
             commit: 322d4df8cb51b531a998de92298914a6710d7677

--- a/projects/tedge-rauc.lock.yaml
+++ b/projects/tedge-rauc.lock.yaml
@@ -13,6 +13,6 @@ overrides:
         meta-rust:
             commit: a5136be2ba408af1cc8afcde1c8e3d787dadd934
         meta-tedge:
-            commit: 18e085137f589c7473a045da2deeb358564992df
+            commit: 0f2e1f67f7ed699b7cdc97d46c7dfde9e9457ebd
         poky:
             commit: 322d4df8cb51b531a998de92298914a6710d7677


### PR DESCRIPTION
Update to latest meta-tedge layer to fix a bug where the firmware status events assume that it is always run on the main device