### PR TITLE
chore: update lock files and to thin-edge.io 1.3.1

### DIFF
--- a/projects/tedge-bin-rauc.lock.yaml
+++ b/projects/tedge-bin-rauc.lock.yaml
@@ -3,7 +3,7 @@ header:
 overrides:
     repos:
         meta-openembedded:
-            commit: 9a24b7679810628b594cc5a9b52f77f53d37004f
+            commit: dd3d2293ffdf2559f8a433f241765a8ab50cd085
         meta-raspberrypi:
             commit: d7544f35756d87834e8b4bf3e3e733c771d380ae
         meta-rauc:
@@ -11,6 +11,6 @@ overrides:
         meta-rauc-community:
             commit: c3f3ab4c587f51a74a76546ce2813c8be7c6d128
         meta-tedge:
-            commit: 794db081ed663ab5b4b19b787bf53a0006c5811d
+            commit: eac966ce0239c688650605bebc99f68dc8f07291
         poky:
-            commit: e938b18b5342bd28eadb44ad39dbf1f5cf5be09b
+            commit: 47ffa50db25a5ceeb73a3a0600dd9e68274d184f

--- a/projects/tedge-mender-qemu.lock.yaml
+++ b/projects/tedge-mender-qemu.lock.yaml
@@ -5,10 +5,10 @@ overrides:
         meta-mender:
             commit: 9efa9409684e303472ed9dae749ab663909eb689
         meta-openembedded:
-            commit: 9a24b7679810628b594cc5a9b52f77f53d37004f
+            commit: dd3d2293ffdf2559f8a433f241765a8ab50cd085
         meta-rust:
             commit: a5136be2ba408af1cc8afcde1c8e3d787dadd934
         meta-tedge:
-            commit: 794db081ed663ab5b4b19b787bf53a0006c5811d
+            commit: eac966ce0239c688650605bebc99f68dc8f07291
         poky:
-            commit: e938b18b5342bd28eadb44ad39dbf1f5cf5be09b
+            commit: 47ffa50db25a5ceeb73a3a0600dd9e68274d184f

--- a/projects/tedge-mender.lock.yaml
+++ b/projects/tedge-mender.lock.yaml
@@ -5,12 +5,12 @@ overrides:
         meta-mender:
             commit: 9efa9409684e303472ed9dae749ab663909eb689
         meta-openembedded:
-            commit: 9a24b7679810628b594cc5a9b52f77f53d37004f
+            commit: dd3d2293ffdf2559f8a433f241765a8ab50cd085
         meta-raspberrypi:
             commit: d7544f35756d87834e8b4bf3e3e733c771d380ae
         meta-rust:
             commit: a5136be2ba408af1cc8afcde1c8e3d787dadd934
         meta-tedge:
-            commit: 794db081ed663ab5b4b19b787bf53a0006c5811d
+            commit: eac966ce0239c688650605bebc99f68dc8f07291
         poky:
-            commit: e938b18b5342bd28eadb44ad39dbf1f5cf5be09b
+            commit: 47ffa50db25a5ceeb73a3a0600dd9e68274d184f

--- a/projects/tedge-rauc.lock.yaml
+++ b/projects/tedge-rauc.lock.yaml
@@ -3,7 +3,7 @@ header:
 overrides:
     repos:
         meta-openembedded:
-            commit: 9a24b7679810628b594cc5a9b52f77f53d37004f
+            commit: dd3d2293ffdf2559f8a433f241765a8ab50cd085
         meta-raspberrypi:
             commit: d7544f35756d87834e8b4bf3e3e733c771d380ae
         meta-rauc:
@@ -13,6 +13,6 @@ overrides:
         meta-rust:
             commit: a5136be2ba408af1cc8afcde1c8e3d787dadd934
         meta-tedge:
-            commit: 794db081ed663ab5b4b19b787bf53a0006c5811d
+            commit: eac966ce0239c688650605bebc99f68dc8f07291
         poky:
-            commit: e938b18b5342bd28eadb44ad39dbf1f5cf5be09b
+            commit: 47ffa50db25a5ceeb73a3a0600dd9e68274d184f


### PR DESCRIPTION
Update the lock files and update to thin-edge.io 1.3.1