### PR TITLE
feat: add readonly root filesystem example

### DIFF
--- a/projects/config/read-only-with-overlay.yaml
+++ b/projects/config/read-only-with-overlay.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
+header:
+  version: 14
+
+local_conf_header:
+  meta-read-only: |
+    IMAGE_FEATURES:append = " read-only-rootfs overlayfs-etc"
+    IMAGE_FEATURES:remove = " package-management"
+
+    OVERLAYFS_ETC_MOUNT_POINT ?= "/mnt/etc"
+    OVERLAYFS_ETC_FSTYPE ?= "ext4"
+    OVERLAYFS_ETC_DEVICE ?= "/dev/mmcblk0p5"

--- a/projects/config/read-only.yaml
+++ b/projects/config/read-only.yaml
@@ -7,6 +7,11 @@ local_conf_header:
     IMAGE_FEATURES:append = " read-only-rootfs"
     IMAGE_FEATURES:remove = " package-management"
 
+    # Note: /data/tedge will be created when the image is used as /data does not exist at build time
+    TEDGE_CONFIG_DIR = "/etc/tedge-default"
+    TEDGE_CONFIG_SYMLINK = "/etc/tedge"
+    TEDGE_CONFIG_SYMLINK_SRC = "/data/tedge"
+
     # `has_journal` interferes with the checksum of the image when viewed from the block device. Oddly
     # enough it is not present on disk, IOW, when the image is mounted readonly, the physical checksum
     # on disk, and the checksum of the corresponding block device, are not the same. Work around this by

--- a/projects/config/read-only.yaml
+++ b/projects/config/read-only.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
+header:
+  version: 14
+
+local_conf_header:
+  meta-read-only: |
+    IMAGE_FEATURES:append = " read-only-rootfs"
+    IMAGE_FEATURES:remove = " package-management"
+
+    # `has_journal` interferes with the checksum of the image when viewed from the block device. Oddly
+    # enough it is not present on disk, IOW, when the image is mounted readonly, the physical checksum
+    # on disk, and the checksum of the corresponding block device, are not the same. Work around this by
+    # disabling the journal for read-only filesystems, where it is useless anyway.
+    EXTRA_IMAGECMD:ext4:append = "${@bb.utils.contains('IMAGE_FEATURES', 'read-only-rootfs', ' -O ^has_journal', '', d)}"

--- a/projects/tedge-bin-rauc.lock.yaml
+++ b/projects/tedge-bin-rauc.lock.yaml
@@ -11,6 +11,6 @@ overrides:
         meta-rauc-community:
             commit: c3f3ab4c587f51a74a76546ce2813c8be7c6d128
         meta-tedge:
-            commit: eac966ce0239c688650605bebc99f68dc8f07291
+            commit: f8aca496908f66a34f691c3a09199f17d46df11c
         poky:
             commit: 47ffa50db25a5ceeb73a3a0600dd9e68274d184f

--- a/projects/tedge-bin-rauc.yaml
+++ b/projects/tedge-bin-rauc.yaml
@@ -6,6 +6,7 @@ header:
     - config/raspberrypi.yaml
     - config/rauc-raspberrypi.yaml
     - config/package-management.yaml
+    - config/read-only.yaml
 
 machine: raspberrypi4-64
 distro: poky

--- a/projects/tedge-mender-qemu.lock.yaml
+++ b/projects/tedge-mender-qemu.lock.yaml
@@ -9,6 +9,6 @@ overrides:
         meta-rust:
             commit: a5136be2ba408af1cc8afcde1c8e3d787dadd934
         meta-tedge:
-            commit: eac966ce0239c688650605bebc99f68dc8f07291
+            commit: f8aca496908f66a34f691c3a09199f17d46df11c
         poky:
             commit: 47ffa50db25a5ceeb73a3a0600dd9e68274d184f

--- a/projects/tedge-mender.lock.yaml
+++ b/projects/tedge-mender.lock.yaml
@@ -11,6 +11,6 @@ overrides:
         meta-rust:
             commit: a5136be2ba408af1cc8afcde1c8e3d787dadd934
         meta-tedge:
-            commit: eac966ce0239c688650605bebc99f68dc8f07291
+            commit: f8aca496908f66a34f691c3a09199f17d46df11c
         poky:
             commit: 47ffa50db25a5ceeb73a3a0600dd9e68274d184f

--- a/projects/tedge-rauc.lock.yaml
+++ b/projects/tedge-rauc.lock.yaml
@@ -13,6 +13,6 @@ overrides:
         meta-rust:
             commit: a5136be2ba408af1cc8afcde1c8e3d787dadd934
         meta-tedge:
-            commit: 6398dfd354dd997e8598e6dc2e0fa6c58668dbfd
+            commit: f8aca496908f66a34f691c3a09199f17d46df11c
         poky:
             commit: 47ffa50db25a5ceeb73a3a0600dd9e68274d184f

--- a/projects/tedge-rauc.lock.yaml
+++ b/projects/tedge-rauc.lock.yaml
@@ -13,6 +13,6 @@ overrides:
         meta-rust:
             commit: a5136be2ba408af1cc8afcde1c8e3d787dadd934
         meta-tedge:
-            commit: eac966ce0239c688650605bebc99f68dc8f07291
+            commit: a1cc465035a1aff9d62ed2915e743158e97ccc8c
         poky:
             commit: 47ffa50db25a5ceeb73a3a0600dd9e68274d184f

--- a/projects/tedge-rauc.lock.yaml
+++ b/projects/tedge-rauc.lock.yaml
@@ -13,6 +13,6 @@ overrides:
         meta-rust:
             commit: a5136be2ba408af1cc8afcde1c8e3d787dadd934
         meta-tedge:
-            commit: a1cc465035a1aff9d62ed2915e743158e97ccc8c
+            commit: 6398dfd354dd997e8598e6dc2e0fa6c58668dbfd
         poky:
             commit: 47ffa50db25a5ceeb73a3a0600dd9e68274d184f

--- a/projects/tedge-rauc.yaml
+++ b/projects/tedge-rauc.yaml
@@ -53,8 +53,7 @@ repos:
     branch: master
 
   meta-tedge:
-    url: "https://github.com/reubenmiller/meta-tedge.git"
-    branch: fix-readonly-support
+    url: "https://github.com/thin-edge/meta-tedge.git"
     layers:
       meta-tedge:
       meta-tedge-common:

--- a/projects/tedge-rauc.yaml
+++ b/projects/tedge-rauc.yaml
@@ -53,7 +53,8 @@ repos:
     branch: master
 
   meta-tedge:
-    url: "https://github.com/thin-edge/meta-tedge.git"
+    url: "https://github.com/reubenmiller/meta-tedge.git"
+    branch: fix-readonly-support
     layers:
       meta-tedge:
       meta-tedge-common:


### PR DESCRIPTION
Add example configuration (snippet) to enable `read-only-rootfs` support.

The configuration is not used by default, however it can be added to any project by using importing one of the following configs:
* `projects/config/read-only.yaml` - read only rootfs with no overlay
* `projects/config/read-only-with-overlay.yaml` - read only rootfs with an overlay filesystem for `/etc`