### PR TITLE
feat: support mender client 4.x

### DIFF
--- a/projects/config/mender-raspberrypi.yaml
+++ b/projects/config/mender-raspberrypi.yaml
@@ -12,3 +12,16 @@ local_conf_header:
     IMAGE_FSTYPES:remove = " rpi-sdimg"
     SDIMG_ROOTFS_TYPE = "ext4"
     MENDER_BOOT_PART_SIZE_MB = "64"
+
+    # Disable mender systemd dependency
+    MENDER_FEATURES_DISABLE:append = " mender-systemd"
+
+    # mender golang client 3.x
+    #PREFERRED_PROVIDER_mender-native = "mender-client-native"
+    #PREFERRED_RPROVIDER_mender-auth = "mender-client"
+    #PREFERRED_RPROVIDER_mender-update = "mender-client"
+
+    # mender cpp client >=4.x
+    PREFERRED_PROVIDER_mender-native = "mender-native"
+    PREFERRED_RPROVIDER_mender-auth = "mender"
+    PREFERRED_RPROVIDER_mender-update = "mender"

--- a/projects/tedge-bin-rauc.lock.yaml
+++ b/projects/tedge-bin-rauc.lock.yaml
@@ -3,7 +3,7 @@ header:
 overrides:
     repos:
         meta-openembedded:
-            commit: dd3d2293ffdf2559f8a433f241765a8ab50cd085
+            commit: 4ad41baed6236d499804cbfc4f174042d84fce97
         meta-raspberrypi:
             commit: d7544f35756d87834e8b4bf3e3e733c771d380ae
         meta-rauc:
@@ -11,6 +11,6 @@ overrides:
         meta-rauc-community:
             commit: c3f3ab4c587f51a74a76546ce2813c8be7c6d128
         meta-tedge:
-            commit: f8aca496908f66a34f691c3a09199f17d46df11c
+            commit: 89ce3d130cf1be529edf58c3a876d38afcbe8757
         poky:
-            commit: 47ffa50db25a5ceeb73a3a0600dd9e68274d184f
+            commit: 51bd4260cb9592af4b63059a30f4f977e0a2fad6

--- a/projects/tedge-mender-qemu.lock.yaml
+++ b/projects/tedge-mender-qemu.lock.yaml
@@ -7,7 +7,7 @@ overrides:
         meta-openembedded:
             commit: 4ad41baed6236d499804cbfc4f174042d84fce97
         meta-rust:
-            commit: 6750e846ebcaef9783e11fc6341888235738d238
+            commit: a5136be2ba408af1cc8afcde1c8e3d787dadd934
         meta-tedge:
             commit: 89ce3d130cf1be529edf58c3a876d38afcbe8757
         poky:

--- a/projects/tedge-mender-qemu.lock.yaml
+++ b/projects/tedge-mender-qemu.lock.yaml
@@ -5,10 +5,10 @@ overrides:
         meta-mender:
             commit: 9efa9409684e303472ed9dae749ab663909eb689
         meta-openembedded:
-            commit: dd3d2293ffdf2559f8a433f241765a8ab50cd085
+            commit: 4ad41baed6236d499804cbfc4f174042d84fce97
         meta-rust:
-            commit: a5136be2ba408af1cc8afcde1c8e3d787dadd934
+            commit: 6750e846ebcaef9783e11fc6341888235738d238
         meta-tedge:
-            commit: f8aca496908f66a34f691c3a09199f17d46df11c
+            commit: 89ce3d130cf1be529edf58c3a876d38afcbe8757
         poky:
-            commit: 47ffa50db25a5ceeb73a3a0600dd9e68274d184f
+            commit: 51bd4260cb9592af4b63059a30f4f977e0a2fad6

--- a/projects/tedge-mender.lock.yaml
+++ b/projects/tedge-mender.lock.yaml
@@ -5,12 +5,12 @@ overrides:
         meta-mender:
             commit: 9efa9409684e303472ed9dae749ab663909eb689
         meta-openembedded:
-            commit: dd3d2293ffdf2559f8a433f241765a8ab50cd085
+            commit: 4ad41baed6236d499804cbfc4f174042d84fce97
         meta-raspberrypi:
             commit: d7544f35756d87834e8b4bf3e3e733c771d380ae
         meta-rust:
-            commit: a5136be2ba408af1cc8afcde1c8e3d787dadd934
+            commit: 6750e846ebcaef9783e11fc6341888235738d238
         meta-tedge:
-            commit: f8aca496908f66a34f691c3a09199f17d46df11c
+            commit: 89ce3d130cf1be529edf58c3a876d38afcbe8757
         poky:
-            commit: 47ffa50db25a5ceeb73a3a0600dd9e68274d184f
+            commit: 51bd4260cb9592af4b63059a30f4f977e0a2fad6

--- a/projects/tedge-mender.lock.yaml
+++ b/projects/tedge-mender.lock.yaml
@@ -9,7 +9,7 @@ overrides:
         meta-raspberrypi:
             commit: d7544f35756d87834e8b4bf3e3e733c771d380ae
         meta-rust:
-            commit: 6750e846ebcaef9783e11fc6341888235738d238
+            commit: a5136be2ba408af1cc8afcde1c8e3d787dadd934
         meta-tedge:
             commit: 89ce3d130cf1be529edf58c3a876d38afcbe8757
         poky:

--- a/projects/tedge-rauc.lock.yaml
+++ b/projects/tedge-rauc.lock.yaml
@@ -3,7 +3,7 @@ header:
 overrides:
     repos:
         meta-openembedded:
-            commit: dd3d2293ffdf2559f8a433f241765a8ab50cd085
+            commit: 4ad41baed6236d499804cbfc4f174042d84fce97
         meta-raspberrypi:
             commit: d7544f35756d87834e8b4bf3e3e733c771d380ae
         meta-rauc:
@@ -11,8 +11,8 @@ overrides:
         meta-rauc-community:
             commit: c3f3ab4c587f51a74a76546ce2813c8be7c6d128
         meta-rust:
-            commit: a5136be2ba408af1cc8afcde1c8e3d787dadd934
+            commit: 6750e846ebcaef9783e11fc6341888235738d238
         meta-tedge:
-            commit: f8aca496908f66a34f691c3a09199f17d46df11c
+            commit: 89ce3d130cf1be529edf58c3a876d38afcbe8757
         poky:
-            commit: 47ffa50db25a5ceeb73a3a0600dd9e68274d184f
+            commit: 51bd4260cb9592af4b63059a30f4f977e0a2fad6

--- a/projects/tedge-rauc.lock.yaml
+++ b/projects/tedge-rauc.lock.yaml
@@ -11,7 +11,7 @@ overrides:
         meta-rauc-community:
             commit: c3f3ab4c587f51a74a76546ce2813c8be7c6d128
         meta-rust:
-            commit: 6750e846ebcaef9783e11fc6341888235738d238
+            commit: a5136be2ba408af1cc8afcde1c8e3d787dadd934
         meta-tedge:
             commit: 89ce3d130cf1be529edf58c3a876d38afcbe8757
         poky:


### PR DESCRIPTION
Add support for building an image with mender 4.x
* Support for downloading an artifact file directly from Cumulocity URL (this was broken in mender 3.x)
* Auto detect which mender version is being used (mender 3.x or mender 4.x)
* Don't overwrite existing sudoers.d/ files when running the mender state scripts so that images can be used to update these files instead.
* Remove mender dependency on systemd to allow images to be built without systemd (though systemd is still the preferred init system)